### PR TITLE
Fix a bug with the hp bar

### DIFF
--- a/Anature/src/application/controllers/BattleController.java
+++ b/Anature/src/application/controllers/BattleController.java
@@ -369,7 +369,6 @@ public class BattleController
 		HpBar playerHpBar = new HpBar(mPlayerHp, mPlayerHpTotal, scene);
 		playerHpBar.bindX(1.509);
 		playerHpBar.bindY(1.995);
-		playerHpBar.progressProperty().bind(mPlayerHp.divide(mPlayerHpTotal));
 		playerHpBar.visibleProperty().bind(mShowPlayerBars);
 
 		mPane.getChildren().add(playerHpBar);
@@ -377,7 +376,6 @@ public class BattleController
 		HpBar enemyHpBar = new HpBar(mEnemyHp, mEnemyHpTotal, scene);
 		enemyHpBar.bindX(4.15);
 		enemyHpBar.bindY(7.95);
-		enemyHpBar.progressProperty().bind(mEnemyHp.divide(mEnemyHpTotal));
 
 		mPane.getChildren().add(enemyHpBar);
 

--- a/Anature/src/application/views/elements/HpBar.java
+++ b/Anature/src/application/views/elements/HpBar.java
@@ -17,18 +17,17 @@ public class HpBar extends ProgressBar
 		mTotalValue = totalValue;
 		mScene = sceneToBindTo;
 
-		progressProperty().bind(mCurrValue.divide(mTotalValue));
 		prefWidthProperty().bind(mScene.widthProperty().divide(9));
 		prefHeightProperty().bind(mScene.heightProperty().divide(55));
 
 		getStylesheets().add("/resources/css/BattleStyle.css");
 		getStyleClass().add("green-bar");
-		mCurrValue.addListener(new ChangeListener<Number>()
+		progressProperty().addListener(new ChangeListener<Number>()
 		{
 			@Override
 			public void changed(ObservableValue<? extends Number> observable, Number oldValue, Number newValue)
 			{
-				double progress = newValue.doubleValue();
+				double progress = newValue.doubleValue() * 100;
 
 				getStyleClass().removeAll("red-bar", "orange-bar", "yellow-bar", "green-bar");
 				if(progress < 20)
@@ -52,6 +51,14 @@ public class HpBar extends ProgressBar
 				}
 			}
 		});
+		
+		ChangeListener<Number> hpListener = (observable, oldValue, newValue) ->
+		{
+			setProgress(mCurrValue.divide(mTotalValue).get());
+		};
+		
+		mCurrValue.addListener(hpListener);
+		mTotalValue.addListener(hpListener);
 	}
 
 	public void bindX(double toDivideBy)


### PR DESCRIPTION
Fix a bug with hp bars. The color was bound to the current hp's raw value, not the percentage of the bar.