### PR TITLE
Fix Switching into Entry Abilities

### DIFF
--- a/Anature/src/application/controllers/BattleController.java
+++ b/Anature/src/application/controllers/BattleController.java
@@ -1686,6 +1686,16 @@ public class BattleController
 			afterTurnStatusCheck(false, mFightManager.getEnemyAnature());
 
 			nextTurn.run();
+			
+			try
+			{
+				Thread.sleep(100);
+			}
+			
+			catch(InterruptedException e)
+			{
+				LoggerController.logEvent(LoggingTypes.Error, "Sleep after turn was interrupted.");
+			}
 
 			if(mClickQueue.size() != 0 && mClickQueue.upNextName().compareTo("Reset GUI") != 0)
 			{


### PR DESCRIPTION
I found a bug where, if u switch to an Anature with an entry ability the game can freeze due to it processing to quickly.